### PR TITLE
Change from 0.0.0.0 to 127.0.0.1 to restrict access to localhost only

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -165,4 +165,4 @@ def root():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=7187)
+    uvicorn.run(app, host="127.0.0.1", port=7187)


### PR DESCRIPTION
Network Security
Issue: The server is binding to 0.0.0.0, which exposes it on all network interfaces. Risk: This makes the service accessible from any network that can reach the host, potentially exposing it to unauthorized access. Recommendation: Unless this is required for your use case, consider binding to 127.0.0.1 to restrict access to the local machine only.

Pls test before accepting; I did a quick a.i. security code review which recommended this. Hope this helps.